### PR TITLE
Update 03_bounding_boxes_index_ocr.ipynb

### DIFF
--- a/03_bounding_boxes_index_ocr.ipynb
+++ b/03_bounding_boxes_index_ocr.ipynb
@@ -212,7 +212,7 @@
     "for c in cnts:\n",
     "    x, y, w, h = cv2.boundingRect(c)\n",
     "    if h > 200 and w > 20:\n",
-    "        roi = image[y:y+h, x:x+h]\n",
+    "        roi = image[y:y+h, x:x+w]\n",
     "        cv2.imwrite(\"temp/index_roi.png\", roi)\n",
     "        cv2.rectangle(image, (x, y), (x+w, y+h), (36, 255, 12), 2)\n",
     "cv2.imwrite(\"temp/index_bbox_new.png\", image)"


### PR DESCRIPTION
Changed dimensions of bounding boxes for the x-dimension during ROI calculation. Code will now correctly iterate through bounding boxes, distinguishing between marginalia and main text body. Previous code would have "cascading" bounding boxes per iteration. For one iteration the bounding box would encompass three columns, the next iteration would have two columns, and the last one would be the single column. Although this final, single column was a desired column to extract, no iteration resulted in identifying the first two columns by themselves.